### PR TITLE
SamplerState constructor changed from private to public

### DIFF
--- a/sources/engine/SiliconStudio.Paradox.Graphics/Direct3D/SamplerState.Direct3D.cs
+++ b/sources/engine/SiliconStudio.Paradox.Graphics/Direct3D/SamplerState.Direct3D.cs
@@ -19,7 +19,7 @@ namespace SiliconStudio.Paradox.Graphics
         /// <param name="device">The device.</param>
         /// <param name="name">The name.</param>
         /// <param name="samplerStateDescription">The sampler state description.</param>
-        private SamplerState(GraphicsDevice device, SamplerStateDescription samplerStateDescription) : base(device)
+        public SamplerState(GraphicsDevice device, SamplerStateDescription samplerStateDescription) : base(device)
         {
             Description = samplerStateDescription;
 


### PR DESCRIPTION
Changed the SamplerState constructor from private to public to match the
other render states such as RasterizerState, which also has a public
constructor. The constructors provide an alternative to using the static
New() method.
