### PR TITLE
Set GameForm background color to black by default

### DIFF
--- a/sources/engine/SiliconStudio.Paradox.Games/Desktop/GameForm.cs
+++ b/sources/engine/SiliconStudio.Paradox.Games/Desktop/GameForm.cs
@@ -94,6 +94,8 @@ namespace SiliconStudio.Paradox.Games
         public GameForm(String text)
         {
             Text = text;
+
+            BackColor = System.Drawing.Color.Black;
             ClientSize = new System.Drawing.Size(800, 600);
 
             ResizeRedraw = true;


### PR DESCRIPTION
As suggested by @xen2, this is a fix for issue #54.
