### PR TITLE
Added missing 'lineadj' hlsl parameter qualifier

### DIFF
--- a/sources/common/shaders/SiliconStudio.Shaders/Ast/Hlsl/ParameterQualifier.cs
+++ b/sources/common/shaders/SiliconStudio.Shaders/Ast/Hlsl/ParameterQualifier.cs
@@ -21,6 +21,11 @@ namespace SiliconStudio.Shaders.Ast.Hlsl
         public static readonly Ast.ParameterQualifier Line = new Ast.ParameterQualifier("line");
 
         /// <summary>
+        ///   LineAdjacent modifier, only for method parameters in Geometry Shader.
+        /// </summary>
+        public static readonly Ast.ParameterQualifier LineAdj = new Ast.ParameterQualifier("lineadj");
+
+        /// <summary>
         ///   Triangle modifier, only for method parameters in Geometry Shader.
         /// </summary>
         public static readonly Ast.ParameterQualifier Triangle = new Ast.ParameterQualifier("triangle");

--- a/sources/common/shaders/SiliconStudio.Shaders/Grammar/Hlsl/HlslGrammar.cs
+++ b/sources/common/shaders/SiliconStudio.Shaders/Grammar/Hlsl/HlslGrammar.cs
@@ -485,7 +485,7 @@ namespace SiliconStudio.Shaders.Grammar.Hlsl
 
             method_declarator.Rule |= method_special_identifier + "(" + parameter_list + ")";
 
-            parameter_qualifier.Rule = storage_qualifier | Keyword("in") | Keyword("out") | Keyword("inout") | Keyword("point") | Keyword("line") | Keyword("triangle") | Keyword("triangleadj");
+            parameter_qualifier.Rule = storage_qualifier | Keyword("in") | Keyword("out") | Keyword("inout") | Keyword("point") | Keyword("line") | Keyword("lineadj") | Keyword("triangle") | Keyword("triangleadj");
             parameter_qualifier.AstNodeCreator = CreateParameterQualifier;
 
             parameter_qualifier_pre_list_opt.Rule = parameter_qualifier.ListOpt();


### PR DESCRIPTION
Possibly an oversight? Changes work fine on desktop. I didn't test on OpenGL platforms, but the conversion seems to be already in place.
