### PR TITLE
Batch script "00-BuildParadox.bat" now works with VS2013.

### DIFF
--- a/build/00-BuildParadox.bat
+++ b/build/00-BuildParadox.bat
@@ -17,9 +17,9 @@ SET ProgFiles86Root=%ProgramFiles(x86)%
 IF NOT "%ProgFiles86Root%"=="" GOTO win64
 SET ProgFiles86Root=%ProgramFiles%
 :win64
-set VS_VCVARSALL=%ProgFiles86Root%\Microsoft Visual Studio 11.0\vc\vcvarsall.bat
+set VS_VCVARSALL=%ProgFiles86Root%\Microsoft Visual Studio 12.0\vc\vcvarsall.bat
 IF EXIST "%VS_VCVARSALL%" GOTO :vcvarok
-echo Error, unable to find path Visual Studio 2012 Path: [%VS_VCVARSALL%]
+echo Error, unable to find path Visual Studio 2013 Path: [%VS_VCVARSALL%]
 exit /b
 :vcvarok
 call "%VS_VCVARSALL%" x86
@@ -29,11 +29,11 @@ IF EXIST "%PARADOX_OUTPUT_DIR%" rmdir /S /Q %PARADOX_OUTPUT_DIR%
 REM msbuild Clean
 IF EXIST "%PARADOX_BUILD_LOG%" del /F "%PARADOX_BUILD_LOG%"
 REM /p:GenerateDoc=true
-msbuild /nologo /tv:4.0 /t:Clean /verbosity:minimal /fl "/flp:Summary;Verbosity=minimal;logfile=%PARADOX_BUILD_LOG%" "/p:%PARADOX_PLATFORM%" %PARADOX_SOLUTION%
+msbuild /nologo /tv:12.0 /t:Clean /verbosity:minimal /fl "/flp:Summary;Verbosity=minimal;logfile=%PARADOX_BUILD_LOG%" "/p:%PARADOX_PLATFORM%" %PARADOX_SOLUTION%
 if %ERRORLEVEL% neq 0 GOTO :error_pause
 REM msbuild Build
 IF EXIST "%PARADOX_BUILD_LOG%" del /F "%PARADOX_BUILD_LOG%"
-msbuild /nologo /tv:4.0 /t:Build /verbosity:minimal /fl "/flp:Summary;Verbosity=minimal;logfile=%PARADOX_BUILD_LOG%" "/p:%PARADOX_PLATFORM%" %PARADOX_SOLUTION%
+msbuild /nologo /tv:12.0 /t:Build /verbosity:minimal /fl "/flp:Summary;Verbosity=minimal;logfile=%PARADOX_BUILD_LOG%" "/p:%PARADOX_PLATFORM%" %PARADOX_SOLUTION%
 if %ERRORLEVEL% neq 0 GOTO :error_pause
 GOTO :end
 :error_pause


### PR DESCRIPTION
Visual Studio 2013 is a requirement to build Paradox according to https://github.com/SiliconStudio/paradox/blob/master/doc/GettingStarted.md, but the "00-BuildParadox.bat" batch file fails on my system using VS2013.

For a bit more information, see the issue I raised:  #177

These changes fix the issues I had:

- Changed the batch script to look for vsvarsall.bat in the VS2013 directory instead of the VS2012 one.
- Changed msbuild to use ToolsVersion 12.0 instead of 4.0.

This is my first ever pull request, so be gentle :-)