### PR TITLE
(AudioEngine.Windows.Desktop.cs)Fix... crashing Surround Environment..

### DIFF
--- a/sources/engine/SiliconStudio.Paradox.Audio/AudioEngine.Windows.Desktop.cs
+++ b/sources/engine/SiliconStudio.Paradox.Audio/AudioEngine.Windows.Desktop.cs
@@ -233,7 +233,12 @@ namespace SiliconStudio.Paradox.Audio
                     break;
             }
         }
-        
+
+        private int GetAudioDeviceChannels()
+        {
+            return XAudio2.GetDeviceDetails(0).OutputFormat.Channels;
+        }
+
         private void UpdateMusicVolume()
         {
             // volume factor used in order to adjust Sound Music and Sound Effect Maximum volumes
@@ -242,7 +247,11 @@ namespace SiliconStudio.Paradox.Audio
             if (streamVolume != null)
             {
                 var vol = volumeAdjustFactor * currentMusic.Volume;
-                streamVolume.SetAllVolumes(2, new[] { vol, vol });
+                var channels = GetAudioDeviceChannels();
+                var volumes = new float[channels];
+                for (int i = 0; i < channels; i++)
+                    volumes[i] = vol;
+                streamVolume.SetAllVolumes(channels, volumes);
             }
         }
         


### PR DESCRIPTION
fix crashing at "streamVolume.SetAllVolumes(2, new[] { vol, vol });" on surround environment.


![visio-surround_issue](https://cloud.githubusercontent.com/assets/4279032/9624159/d5662d0c-5184-11e5-9102-585f03464ba0.png)


